### PR TITLE
Add missing hooks() function

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=pl.treksoft
-version=0.0.4
+version=0.0.5
 systemProp.kotlinVersion=1.4.0
 javaVersion=1.8
 

--- a/src/main/kotlin/pl/treksoft/navigo/Navigo.kt
+++ b/src/main/kotlin/pl/treksoft/navigo/Navigo.kt
@@ -40,6 +40,7 @@ external open class Navigo(root: String? = definedExternally, useHash: Boolean? 
     open fun destroy(): Unit = definedExternally
     open fun lastRouteResolved(): dynamic = definedExternally
     open fun historyAPIUpdateMethod(state: String): Unit = definedExternally
+    open fun hooks(hooks: NavigoHooks): Unit = definedExternally
 }
 
 object Factory {


### PR DESCRIPTION
caveat: I haven't tested this as I haven't figured out a nice workflow for testing these JS wrappers.  

It seemed like the hooks() function (https://github.com/krasimir/navigo/blob/e727872e5c44f0df23d364afdd4164f4823b4751/src/index.js#L378) had been missed from the API so I've added it.  This would also require an associated uplift of the navigo-kotlin dependency in KVision.